### PR TITLE
Fix account deletion logic and add tests

### DIFF
--- a/api/controllers/accountController.js
+++ b/api/controllers/accountController.js
@@ -172,17 +172,17 @@ function accountContrl({ moment, AuthHelp }) {
       try {
         const { rows } = await db.query(query, values);
 
-        const [, account] = rows;
+        const [account] = rows;
 
-        if (!account) {
+        if (account) {
           return res.status(200).json({
             status: 200,
             message: 'Account successfully deleted',
           });
         }
 
-        return res.error(400).json({
-          status: 200,
+        return res.status(400).json({
+          status: 400,
           error: 'Failed to delete account, try again',
         });
 

--- a/api/test/index-test.js
+++ b/api/test/index-test.js
@@ -470,25 +470,48 @@ describe('UNIT TESTS FOR CONTROLLERS', () => {
   //   });
   // });
 
-  // describe('DELETE REQUEST', () => {
-  //   it('it should DELETE account', () => {
-  //     chai.request(app)
-  //       .delete('/api/v1/accounts/4952853906')
-  //       .end((err, res) => {
-  //         res.should.have.status(200);
-  //         res.body.should.have.property('message').to.equals('Account deleted');
-  //         res.body.should.have.property('status').to.equals(200);
-  //       });
-  //   });
+  describe('/DELETE REQUEST Delete account', () => {
+    let userToken;
 
-  //   it('it should return error', () => {
-  //     chai.request(app)
-  //       .delete('/api/v1/accounts/2345566767')
-  //       .end((err, res) => {
-  //         res.should.have.status(400);
-  //         res.body.should.have.property('error').to.equals('Account not found');
-  //         res.body.should.have.property('status').to.equals(400);
-  //       });
-  //   });n
-  // });
+    before((done) => {
+      chai
+        .request(app)
+        .post('/api/v1/auth/signin')
+        .send({
+          email: 'abraham.ossai@gmail.com',
+          password: 'andela1234',
+        })
+        .end((err, res) => {
+          const { token } = res.body.data;
+          userToken = `Bearer ${token}`;
+          done();
+        });
+    });
+
+    it('it should DELETE account', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/accounts/3657878777')
+        .set('Authorization', userToken)
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.property('message').to.equals('Account successfully deleted');
+          res.body.should.have.property('status').to.equals(200);
+          done();
+        });
+    });
+
+    it('it should return error for unknown account', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/accounts/2345566767')
+        .set('Authorization', userToken)
+        .end((err, res) => {
+          res.should.have.status(404);
+          res.body.should.have.property('error').to.equals('Account not found');
+          res.body.should.have.property('status').to.equals(404);
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- fix account deletion response logic
- add tests for account deletion success and failure

## Testing
- `npm test` *(fails: it should sign up user)*

------
https://chatgpt.com/codex/tasks/task_e_689a6930db88832b91658e12054e3638